### PR TITLE
use keychain if available to automatically start ssh-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is assumed that your login password is identical to the password of the keys.
 
 For Arch Linux users is already a [pam_exec-ssh-git](https://aur.archlinux.org/packages/pam_exec-ssh-git/) package in the AUR.
 
-Otherwise just copy the script, set the permissions and install the dependencies `pam` and `expect`.
+Otherwise just copy the script, set the permissions and install the dependencies `pam` and `expect` and optionally `keychain`.
 
 ```sh
 cp pam_exec-ssh /usr/bin/pam_exec-ssh
@@ -26,7 +26,14 @@ chmod 755 /usr/bin/pam_exec-ssh
 ## Configuration
 
 You need a running `ssh-agent` that have to be started before you login.
-You can start your agent [manually](https://wiki.archlinux.org/index.php/SSH_keys#ssh-agent) or as a [systemd user service](https://wiki.archlinux.org/index.php/SSH_keys#Start_ssh-agent_with_systemd_user).
+If you have `keychain` installed, the script will run it and start the `ssh-agent` automatically.
+Be sure to also start it in your `~/.bashrc` to get the environment variables set correctly, for example:
+
+```
+eval $(keychain --eval --quiet)
+```
+
+Of course you can also start your agent [manually](https://wiki.archlinux.org/index.php/SSH_keys#ssh-agent) or as a [systemd user service](https://wiki.archlinux.org/index.php/SSH_keys#Start_ssh-agent_with_systemd_user).
 
 Make sure that the socket path is correct.
 `pam_exec-ssh` use `/run/user/YOUR-USER-ID/ssh-agent.socket` for it.

--- a/pam_exec-ssh
+++ b/pam_exec-ssh
@@ -24,8 +24,12 @@ else
         read -r PAM_PASS
         PAM_PASS=$(echo "$PAM_PASS" | sed 's/\$/\\\$/')
 
-        SSH_AUTH_SOCK=/run/user/$(id -u "$PAM_USER")/ssh-agent.socket
-        export SSH_AUTH_SOCK
+        if hash keychain 2>/dev/null; then
+                eval $(keychain --eval --quiet)
+        else
+                SSH_AUTH_SOCK=/run/user/$(id -u "$PAM_USER")/ssh-agent.socket
+                export SSH_AUTH_SOCK
+        fi
 
         find "$unlockdir" -maxdepth 1 ! -wholename "$unlockdir" | while read -r key; do
             printf 'log_user 1\n\nspawn ssh-add "%s"\n\nexpect "Enter passphrase for %s" {\nsend "%s\r"\n}\n\nexpect eof' "$key" "$key" "$PAM_PASS" | expect

--- a/pam_exec-ssh
+++ b/pam_exec-ssh
@@ -25,7 +25,7 @@ else
         PAM_PASS=$(echo "$PAM_PASS" | sed 's/\$/\\\$/')
 
         if hash keychain 2>/dev/null; then
-                eval $(keychain --eval --quiet)
+                eval "$(keychain --eval --quiet)"
         else
                 SSH_AUTH_SOCK=/run/user/$(id -u "$PAM_USER")/ssh-agent.socket
                 export SSH_AUTH_SOCK


### PR DESCRIPTION
I tried to start the ssh-agent as a user service, but somehow the timing was off and it did not seem to start before the script tried to add the keys. So instead I added an option to use keychain, if installed.

Maybe you find this usefull.

In any case: thank you for the script, works perfectly for me with greetd, while pam_ssh did not.

cheers!
Daniel