### PR TITLE
Fix recursive su execution of script as logon user for recent util-linux versions.

### DIFF
--- a/pam_exec-ssh
+++ b/pam_exec-ssh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$(id -un)" != "$PAM_USER" ]; then
-    su "$PAM_USER" -s "$0" "$@"
+    su "$PAM_USER" -c "$0" "$@"
 else
     if [ -d "/home/$PAM_USER/.ssh/unlock.d" ]; then
         unlockdir="/home/$PAM_USER/.ssh/unlock.d"


### PR DESCRIPTION
The upgrade to util-linux 2.42-1 on Arch Linux breaks the usage of su -s (Error message: /bin/bash: unknown command ***mypassword***

When using su -c instead it works again for me.

Out of curiosity (something to learn for me): why is it using calling the script as a shell (su -s) instead of as a command (su -c)?